### PR TITLE
\x80 replaced with \x81

### DIFF
--- a/index.js
+++ b/index.js
@@ -1039,61 +1039,61 @@ instance.prototype.action = function(action) {
 	switch (action.action) {
 
 		case 'left':
-			cmd = '\x80\x01\x06\x01'+ String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) + String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) +'\x01\x03\xFF';
+			cmd = '\x81\x01\x06\x01'+ String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) + String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) +'\x01\x03\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'right':
-			cmd = '\x80\x01\x06\x01'+ String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) + String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) +'\x02\x03\xFF';
+			cmd = '\x81\x01\x06\x01'+ String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) + String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) +'\x02\x03\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'up':
-			cmd = '\x80\x01\x06\x01'+ String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) + String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) +'\x03\x01\xFF';
+			cmd = '\x81\x01\x06\x01'+ String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) + String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) +'\x03\x01\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'down':
-			cmd = '\x80\x01\x06\x01'+ String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) + String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) +'\x03\x02\xFF';
+			cmd = '\x81\x01\x06\x01'+ String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) + String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) +'\x03\x02\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'upLeft':
-			cmd = '\x80\x01\x06\x01'+ String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) + String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) +'\x01\x01\xFF';
+			cmd = '\x81\x01\x06\x01'+ String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) + String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) +'\x01\x01\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'upRight':
-			cmd = '\x80\x01\x06\x01'+ String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) + String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) +'\x02\x01\xFF';
+			cmd = '\x81\x01\x06\x01'+ String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) + String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) +'\x02\x01\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'downLeft':
-			cmd = '\x80\x01\x06\x01'+ String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) + String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) +'\x01\x02\xFF';
+			cmd = '\x81\x01\x06\x01'+ String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) + String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) +'\x01\x02\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'downRight':
-			cmd = '\x80\x01\x06\x01'+ String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) + String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) +'\x02\x02\xFF';
+			cmd = '\x81\x01\x06\x01'+ String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) + String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) +'\x02\x02\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'stop':
-			cmd = '\x80\x01\x06\x01'+ String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) + String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) +'\x03\x03\xFF';
+			cmd = '\x81\x01\x06\x01'+ String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) + String.fromCharCode(parseInt(self.ptSpeed,16) & 0xFF) +'\x03\x03\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'home':
-			cmd = '\x80\x01\x06\x04\xFF';
+			cmd = '\x81\x01\x06\x04\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'ptSlow':
 			if (opt.bol == '0') {
-				cmd = '\x80\x01\x06\x44\x02\xFF';
+				cmd = '\x81\x01\x06\x44\x02\xFF';
 			}
 			if (opt.bol == '1') {
-				cmd = '\x80\x01\x06\x44\x03\xFF';
+				cmd = '\x81\x01\x06\x44\x03\xFF';
 			}
 			self.sendVISCACommand(cmd);
 			break;
@@ -1136,92 +1136,92 @@ instance.prototype.action = function(action) {
 
 
 		case 'zoomI':
-			cmd = '\x80\x01\x04\x07\x02\xFF';
+			cmd = '\x81\x01\x04\x07\x02\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'zoomO':
-			cmd = '\x80\x01\x04\x07\x03\xFF';
+			cmd = '\x81\x01\x04\x07\x03\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'zoomS':
-			cmd = '\x80\x01\x04\x07\x00\xFF';
+			cmd = '\x81\x01\x04\x07\x00\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'ciZoom':
 			if (opt.bol == 0){
-				cmd = '\x80\x01\x04\x06\x03\xFF';
+				cmd = '\x81\x01\x04\x06\x03\xFF';
 			}
 			if (opt.bol == 1){
-				cmd = '\x80\x01\x04\x06\x04\xFF';
+				cmd = '\x81\x01\x04\x06\x04\xFF';
 			}
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'focusN':
-			cmd = '\x80\x01\x04\x08\x03\xFF';
+			cmd = '\x81\x01\x04\x08\x03\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'focusF':
-			cmd = '\x80\x01\x04\x08\x02\xFF';
+			cmd = '\x81\x01\x04\x08\x02\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'focusS':
-			cmd = '\x80\x01\x04\x38\x00\xFF';
+			cmd = '\x81\x01\x04\x38\x00\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'focusM':
 			if (opt.bol == 0){
-				cmd = '\x80\x01\x04\x38\x02\xFF';
+				cmd = '\x81\x01\x04\x38\x02\xFF';
 			}
 			if (opt.bol == 1){
-				cmd = '\x80\x01\x04\x38\x03\xFF';
+				cmd = '\x81\x01\x04\x38\x03\xFF';
 			}
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'focusOpaf':
-			cmd = '\x80\x01\x04\x18\x01\xFF';
+			cmd = '\x81\x01\x04\x18\x01\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'expM':
 			if (opt.val == 0){
-				cmd = '\x80\x01\x04\x39\x00\xFF';
+				cmd = '\x81\x01\x04\x39\x00\xFF';
 			}
 			if (opt.val == 1){
-				cmd = '\x80\x01\x04\x39\x03\xFF';
+				cmd = '\x81\x01\x04\x39\x03\xFF';
 			}
 			if (opt.val == 2){
-				cmd = '\x80\x01\x04\x39\x0A\xFF';
+				cmd = '\x81\x01\x04\x39\x0A\xFF';
 			}
 			if (opt.val == 3){
-				cmd = '\x80\x01\x04\x39\x0B\xFF';
+				cmd = '\x81\x01\x04\x39\x0B\xFF';
 			}
 			if (opt.val == 4){
-				cmd = '\x80\x01\x04\x39\x0E\xFF';
+				cmd = '\x81\x01\x04\x39\x0E\xFF';
 			}
 			self.sendVISCACommand(cmd);
 			break;
 
 
 		case 'gainU':
-			cmd = '\x80\x01\x04\x0C\x02\xFF';
+			cmd = '\x81\x01\x04\x0C\x02\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'gainD':
-			cmd = '\x80\x01\x04\x0C\x03\xFF';
+			cmd = '\x81\x01\x04\x0C\x03\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'gainS':
-			var cmd = Buffer.from('\x80\x01\x04\x4C\x00\x00\x00\x00\xFF', 'binary');
+			var cmd = Buffer.from('\x81\x01\x04\x4C\x00\x00\x00\x00\xFF', 'binary');
 			cmd.writeUInt8((parseInt(opt.val,16) & 0xF0) >> 4, 6);
 			cmd.writeUInt8(parseInt(opt.val,16) & 0x0F, 7);
 			self.sendVISCACommand(cmd);
@@ -1229,17 +1229,17 @@ instance.prototype.action = function(action) {
 			break;
 
 		case 'irisU':
-			cmd = '\x80\x01\x04\x0B\x02\xFF';
+			cmd = '\x81\x01\x04\x0B\x02\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'irisD':
-			cmd = '\x80\x01\x04\x0B\x03\xFF';
+			cmd = '\x81\x01\x04\x0B\x03\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'irisS':
-			var cmd = Buffer.from('\x80\x01\x04\x4B\x00\x00\x00\x00\xFF', 'binary');
+			var cmd = Buffer.from('\x81\x01\x04\x4B\x00\x00\x00\x00\xFF', 'binary');
 			cmd.writeUInt8((parseInt(opt.val,16) & 0xF0) >> 4, 6);
 			cmd.writeUInt8(parseInt(opt.val,16) & 0x0F, 7);
 			self.sendVISCACommand(cmd);
@@ -1247,17 +1247,17 @@ instance.prototype.action = function(action) {
 			break;
 
 		case 'shutU':
-			cmd = '\x80\x01\x04\x0A\x02\xFF';
+			cmd = '\x81\x01\x04\x0A\x02\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'shutD':
-			cmd = '\x80\x01\x04\x0A\x03\xFF';
+			cmd = '\x81\x01\x04\x0A\x03\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'shutS':
-			var cmd = Buffer.from('\x80\x01\x04\x4A\x00\x00\x00\x00\xFF', 'binary');
+			var cmd = Buffer.from('\x81\x01\x04\x4A\x00\x00\x00\x00\xFF', 'binary');
 			cmd.writeUInt8((parseInt(opt.val,16) & 0xF0) >> 4, 6);
 			cmd.writeUInt8(parseInt(opt.val,16) & 0x0F, 7);
 			self.sendVISCACommand(cmd);
@@ -1265,26 +1265,26 @@ instance.prototype.action = function(action) {
 			break;
 
 		case 'savePset':
-			cmd ='\x80\x01\x04\x3F\x01' + String.fromCharCode(parseInt(opt.val,16) & 0xFF) + '\xFF';
+			cmd ='\x81\x01\x04\x3F\x01' + String.fromCharCode(parseInt(opt.val,16) & 0xFF) + '\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'recallPset':
-			cmd ='\x80\x01\x04\x3F\x02' + String.fromCharCode(parseInt(opt.val,16) & 0xFF) + '\xFF';
+			cmd ='\x81\x01\x04\x3F\x02' + String.fromCharCode(parseInt(opt.val,16) & 0xFF) + '\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'speedPset':
-			cmd ='\x80\x01\x7E\x01\x0B' + String.fromCharCode(parseInt(opt.val,16) & 0xFF) + String.fromCharCode(parseInt(opt.speed,16) & 0xFF) + '\xFF';
+			cmd ='\x81\x01\x7E\x01\x0B' + String.fromCharCode(parseInt(opt.val,16) & 0xFF) + String.fromCharCode(parseInt(opt.speed,16) & 0xFF) + '\xFF';
 			self.sendVISCACommand(cmd);
 			break;
 
 		case 'tally':
 			if (opt.bol == 0){
-				cmd = '\x80\x01\x7E\x01\x0A\x00\x03\xFF';
+				cmd = '\x81\x01\x7E\x01\x0A\x00\x03\xFF';
 			}
 			if (opt.bol == 1){
-				cmd = '\x80\x01\x7E\x01\x0A\x00\x02\xFF';
+				cmd = '\x81\x01\x7E\x01\x0A\x00\x02\xFF';
 			}
 			self.sendVISCACommand(cmd);
 			break;


### PR DESCRIPTION
From what I have read, Sony Visca over IP requires the command byte, currently \x80 to be a value between 1 and 7 which represents the camera id. Tested this with a lumens camera which didn't respond to \x80 but does to \x81 (when camera id is 1).

Seems that \x88 is a broadcast address but this may be specific to this camera.

Hopefully I have uploaded and forked this correctly. Sorry first time github user