### PR TITLE
Fix: Node12 Buffer Update

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,7 +169,7 @@ var PRESET = [
 
 instance.prototype.sendVISCACommand = function(payload) {
 	var self = this;
-	var buf = new Buffer(32);
+	var buf = Buffer.alloc(32);
 
 		// 0x01 0x00 = VISCA Command
 		buf[0] = 0x01;
@@ -198,7 +198,7 @@ instance.prototype.sendVISCACommand = function(payload) {
 
  instance.prototype.sendControlCommand = function(payload) {
 	var self = this;
-	var buf = new Buffer(32);
+	var buf = Buffer.alloc(32);
 
 	// 0x01 0x00 = VISCA Command
 	buf[0] = 0x02;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "sony-visca",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Protocol",


### PR DESCRIPTION
Updated uses of the deprecated `new Buffer()` to the Node12 compliant functions `Buffer.from()` and `Buffer.alloc()`.

Changes made following the guidelines of Variant 1 of the NodeJS Buffer constructor deprecation guide  https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/