### PR TITLE
Added white balance related presets and actions

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -7,7 +7,7 @@ This module uses the Sony Visca protocol to control PTZ cameras.
 * Type in the port of the device (default is 52381).
 * You can also specify the Camera ID.
 
-### Available Actions
+## Available Actions
 * Pan Left
 * Pan Right
 * Tilt Up
@@ -49,8 +49,21 @@ This module uses the Sony Visca protocol to control PTZ cameras.
 * BackLight Compensation On/Off
 * Aperture +,-,Reset
 * Wide Dynamic Range (Off,Low,Mid,High)
-* White Balance On/Off
 
-### Presets
+**White Balance**
+
+* Set Mode (Auto1, Auto2, Indoor, Outdoor, Manual, One push WB)
+* One push trigger (must be in One Push WB mode)
+* Adjust Red or Green Up or Down (must be in Manual WB mode)
+* Offset - **adjust up** to make redder, **adjust down** to make bluer, or **reset** (works in Auto1, Auto2, or One Push WB modes)
+
+## Companion Presets
+
+* Pan/Tilt
+* Zoom (In, Out, CI)
+* Focus (Near, Far, Auto, On Press Auto Focus)
+* Exposure (Mode, Gain, Iris, Shutter)
+* White Balance (modes, adjustments, trigger)
 * "Cam Presets" are dual function. Tap to recall or press for 2+ seconds to save.
-* "Save Preset" and "Recall Preset" are single function.
+* Save Preset - saves camera preset
+* Recall Preset - recalls camera preset

--- a/index.js
+++ b/index.js
@@ -738,6 +738,34 @@ instance.prototype.init_presets = function () {
 		},
 		{
 			category: 'Exposure',
+			label: 'Auto Exposure Toggle',
+			bank: {
+				style: 'text',
+				text: 'AUTO\\nEXP\\nToggle',
+				size: '18',
+				color: '16777215',
+				bgcolor: self.rgb(0, 0, 0),
+				latch: true
+			},
+			actions: [
+				{
+					action: 'expM',
+					options: {
+						bol: 0,
+					}
+				}
+			],
+			release_actions: [
+				{
+					action: 'expM',
+					options: {
+						bol: 1,
+					}
+				}
+			]
+		},
+		{
+			category: 'Exposure',
 			label: 'Exposure Mode',
 			bank: {
 				style: 'text',
@@ -957,6 +985,27 @@ instance.prototype.init_presets = function () {
 		},
 		{
 			category: 'White Balance',
+			label: 'White Balance Mode - Custom',
+			bank: {
+				style: 'text',
+				text: 'WB\\nCustom',
+				size: '18',
+				color: '16777215',
+				bgcolor: self.rgb(0, 0, 0),
+			},
+			actions: [
+				
+				{
+					action: 'wbCustom',
+					options: {
+						rVal: 192,
+						bVal: 192,
+					}
+				}
+			]
+		},
+		{
+			category: 'White Balance',
 			label: 'White Balance Mode - One push WB',
 			bank: {
 				style: 'text',
@@ -986,7 +1035,7 @@ instance.prototype.init_presets = function () {
 			},
 			actions: [
 				{
-					action: 'whiteBalTrigger',
+					action: 'wbTrigger',
 				}
 			]
 		},
@@ -1379,7 +1428,32 @@ instance.prototype.actions = function (system) {
 				}
 			]
 		},
-		'whiteBalTrigger': { label: 'One push WB trigger' },
+		'wbTrigger': { label: 'One push WB trigger' },
+		'wbCustom': {
+			label: 'White Balance - Custom',
+			options: [
+				{
+					type: 'number',
+					label: 'Red',
+					id: 'rVal',
+					tooltip: 'Sets the red gain, 192 is the default',
+					min: 0,
+					max: 255,
+					default: 192,
+					step: 1
+				},
+				{
+					type: 'number',
+					label: 'Blue',
+					id: 'bVal',
+					tooltip: 'Sets the blue gain, 192 is the default',
+					min: 0,
+					max: 255,
+					default: 192,
+					step: 1
+				}
+			]
+		},
 		'wbRedUp': { label: 'White Balance - Red Gain Up' },
 		'wbRedDown': { label: 'White Balance - Red Gain Down' },
 		'wbBlueUp': { label: 'White Balance - Blue Gain Up' },
@@ -1764,9 +1838,27 @@ instance.prototype.action = function (action) {
 			self.sendVISCACommand(cmd);
 			break;
 
-		case 'whiteBalTrigger':
+		case 'wbTrigger':
 			cmd = String.fromCharCode(parseInt(self.config.id)) + '\x01\x04\x10\x05\xFF';
 			self.sendVISCACommand(cmd);
+			break;
+
+		case 'wbCustom':
+			// Switch to manual
+			cmd = String.fromCharCode(parseInt(self.config.id)) + '\x01\x04\x35\x05\xFF';
+			self.sendVISCACommand(cmd);
+			setTimeout(()=>{
+				// Set Red Gain
+				const r = opt.rVal.toString(16).padStart(2,'0').split('').map(x => String.fromCharCode(parseInt(x,16)));
+				cmd = String.fromCharCode(parseInt(self.config.id)) + '\x01\x04\x43\x00\x00' + r[0] + r[1] +'\xFF';
+				self.sendVISCACommand(cmd);
+				setTimeout(()=>{
+					// Set Blue Gain
+					const b = opt.bVal.toString(16).padStart(2,'0').split('').map(x => String.fromCharCode(parseInt(x,16)));
+					cmd = String.fromCharCode(parseInt(self.config.id)) + '\x01\x04\x44\x00\x00' + b[0] + b[1] +'\xFF';
+					self.sendVISCACommand(cmd);
+				},50);
+			},50);
 			break;
 
 		case 'wbRedUp':

--- a/index.js
+++ b/index.js
@@ -751,7 +751,7 @@ instance.prototype.init_presets = function () {
 				{
 					action: 'expM',
 					options: {
-						bol: 0,
+						val: 0,
 					}
 				}
 			],
@@ -759,7 +759,7 @@ instance.prototype.init_presets = function () {
 				{
 					action: 'expM',
 					options: {
-						bol: 1,
+						val: 1,
 					}
 				}
 			]
@@ -779,7 +779,7 @@ instance.prototype.init_presets = function () {
 				{
 					action: 'expM',
 					options: {
-						bol: 0,
+						val: 0,
 					}
 				}
 			],
@@ -787,7 +787,7 @@ instance.prototype.init_presets = function () {
 				{
 					action: 'expM',
 					options: {
-						bol: 1,
+						val: 1,
 					}
 				}
 			]

--- a/index.js
+++ b/index.js
@@ -859,8 +859,253 @@ instance.prototype.init_presets = function () {
 					action: 'shutD',
 				}
 			]
+		},
+		{
+			category: 'White Balance',
+			label: 'White Balance Mode - Auto1',
+			bank: {
+				style: 'text',
+				text: 'WB\\nAuto1',
+				size: '18',
+				color: '16777215',
+				bgcolor: self.rgb(0, 0, 0),
+			},
+			actions: [
+				{
+					action: 'whiteBal',
+					options: {
+						val: 0,
+					}
+				}
+			]
+		},
+		{
+			category: 'White Balance',
+			label: 'White Balance Mode - Auto2 (ATW)',
+			bank: {
+				style: 'text',
+				text: 'WB\\nAuto2',
+				size: '18',
+				color: '16777215',
+				bgcolor: self.rgb(0, 0, 0),
+			},
+			actions: [
+				{
+					action: 'whiteBal',
+					options: {
+						val: 4,
+					}
+				}
+			]
+		},
+		{
+			category: 'White Balance',
+			label: 'White Balance Mode - Indoor',
+			bank: {
+				style: 'text',
+				text: 'WB\\nIndoor',
+				size: '18',
+				color: '16777215',
+				bgcolor: self.rgb(0, 0, 0),
+			},
+			actions: [
+				{
+					action: 'whiteBal',
+					options: {
+						val: 1,
+					}
+				}
+			]
+		},
+		{
+			category: 'White Balance',
+			label: 'White Balance Mode - Outdoor',
+			bank: {
+				style: 'text',
+				text: 'WB\\nOutdoor',
+				size: '18',
+				color: '16777215',
+				bgcolor: self.rgb(0, 0, 0),
+			},
+			actions: [
+				{
+					action: 'whiteBal',
+					options: {
+						val: 2,
+					}
+				}
+			]
+		},
+		{
+			category: 'White Balance',
+			label: 'White Balance Mode - Manual',
+			bank: {
+				style: 'text',
+				text: 'WB\\nManual',
+				size: '18',
+				color: '16777215',
+				bgcolor: self.rgb(0, 0, 0),
+			},
+			actions: [
+				{
+					action: 'whiteBal',
+					options: {
+						val: 5,
+					}
+				}
+			]
+		},
+		{
+			category: 'White Balance',
+			label: 'White Balance Mode - One push WB',
+			bank: {
+				style: 'text',
+				text: 'WB\\n1 Push',
+				size: '18',
+				color: '16777215',
+				bgcolor: self.rgb(0, 0, 0),
+			},
+			actions: [
+				{
+					action: 'whiteBal',
+					options: {
+						val: 3,
+					}
+				}
+			]
+		},
+		{
+			category: 'White Balance',
+			label: 'One push WB trigger (must be in One push WB mode)',
+			bank: {
+				style: 'text',
+				text: '1 Push\\nTrigger',
+				size: '18',
+				color: '16777215',
+				bgcolor: self.rgb(0, 0, 0),
+			},
+			actions: [
+				{
+					action: 'whiteBalTrigger',
+				}
+			]
+		},
+		{
+			category: 'White Balance',
+			label: 'White Balance - Red Gain Up (must be in WB Manual)',
+			bank: {
+				style: 'text',
+				text: 'Red\\nGain\\nUp',
+				size: '18',
+				color: self.rgb(255, 128, 128),
+				bgcolor: self.rgb(0, 0, 0),
+			},
+			actions: [
+				{
+					action: 'wbRedUp',
+				}
+			]
+		},
+		{
+			category: 'White Balance',
+			label: 'White Balance - Red Gain Down (must be in WB Manual)',
+			bank: {
+				style: 'text',
+				text: 'Red\\nGain\\nDown',
+				size: '18',
+				color: self.rgb(255, 128, 128),
+				bgcolor: self.rgb(0, 0, 0),
+			},
+			actions: [
+				{
+					action: 'wbRedDown',
+				}
+			]
+		},
+		{
+			category: 'White Balance',
+			label: 'White Balance - Blue Gain Up (must be in WB Manual)',
+			bank: {
+				style: 'text',
+				text: 'Blue\\nGain\\nUp',
+				size: '18',
+				color: self.rgb(128, 128, 255),
+				bgcolor: self.rgb(0, 0, 0),
+			},
+			actions: [
+				{
+					action: 'wbBlueUp',
+				}
+			]
+		},
+		{
+			category: 'White Balance',
+			label: 'White Balance - Blue Gain Down (must be in WB Manual)',
+			bank: {
+				style: 'text',
+				text: 'Blue\\nGain\\nDown',
+				size: '18',
+				color: self.rgb(128, 128, 255),
+				bgcolor: self.rgb(0, 0, 0),
+			},
+			actions: [
+				{
+					action: 'wbBlueDown',
+				}
+			]
+		},
+		{
+			category: 'White Balance',
+			label: 'White Balance - Offset Reset',
+			bank: {
+				style: 'text',
+				text: 'WB\\nOffset\\nReset',
+				size: '18',
+				color: '16777215',
+				bgcolor: self.rgb(0, 0, 0),
+			},
+			actions: [
+				{
+					action: 'wbOffsetReset',
+				}
+			]
+		},
+		{
+			category: 'White Balance',
+			label: 'White Balance - Offset Up (more red)',
+			bank: {
+				style: 'text',
+				text: 'WB\\nOffset\\nUp',
+				size: '18',
+				color: '16777215',
+				bgcolor: self.rgb(0, 0, 0),
+			},
+			actions: [
+				{
+					action: 'wbOffsetUp',
+				}
+			]
+		},
+		{
+			category: 'White Balance',
+			label: 'White Balance - Offset Down (more blue)',
+			bank: {
+				style: 'text',
+				text: 'WB\\nOffset\\nDown',
+				size: '18',
+				color: '16777215',
+				bgcolor: self.rgb(0, 0, 0),
+			},
+			actions: [
+				{
+					action: 'wbOffsetDown',
+				}
+			]
 		}
 	];
+	// 'wbOffsetReset': { label: 'White Balance - Offset Reset' },
+	// 'wbOffsetUp': { label: 'White Balance - Offset Up' },
+	// 'wbOffsetDown': { label: 'White Balance - Offset Down' },
 
 	var camPreset;
 	for (camPreset = 0; camPreset < 64; camPreset++) {
@@ -1124,16 +1369,24 @@ instance.prototype.actions = function (system) {
 					label: 'WB setting',
 					id: 'val',
 					choices: [
-						{ id: '0', label: 'Auto' },
+						{ id: '0', label: 'Auto1 - Auto' },
 						{ id: '1', label: 'Indoor' },
 						{ id: '2', label: 'Outdoor' },
-						{ id: '3', label: 'OnePush WB' },
-						{ id: '4', label: 'ATW' },
+						{ id: '3', label: 'One push WB' },
+						{ id: '4', label: 'Auto2 - ATW' },
 						{ id: '5', label: 'Manual' }
 					]
 				}
 			]
 		},
+		'whiteBalTrigger': { label: 'One push WB trigger' },
+		'wbRedUp': { label: 'White Balance - Red Gain Up' },
+		'wbRedDown': { label: 'White Balance - Red Gain Down' },
+		'wbBlueUp': { label: 'White Balance - Blue Gain Up' },
+		'wbBlueDown': { label: 'White Balance - Blue Gain Down' },
+		'wbOffsetReset': { label: 'White Balance - Offset Reset' },
+		'wbOffsetUp': { label: 'White Balance - Offset Up' },
+		'wbOffsetDown': { label: 'White Balance - Offset Down' },
 		'WDR': {
 			label: 'Wide Dynamic Range',
 			options: [
@@ -1511,6 +1764,46 @@ instance.prototype.action = function (action) {
 			self.sendVISCACommand(cmd);
 			break;
 
+		case 'whiteBalTrigger':
+			cmd = String.fromCharCode(parseInt(self.config.id)) + '\x01\x04\x10\x05\xFF';
+			self.sendVISCACommand(cmd);
+			break;
+
+		case 'wbRedUp':
+			cmd = String.fromCharCode(parseInt(self.config.id)) + '\x01\x04\x03\x02\xFF';
+			self.sendVISCACommand(cmd);
+			break;
+
+		case 'wbRedDown':
+			cmd = String.fromCharCode(parseInt(self.config.id)) + '\x01\x04\x03\x03\xFF';
+			self.sendVISCACommand(cmd);
+			break;
+	
+		case 'wbBlueUp':
+			cmd = String.fromCharCode(parseInt(self.config.id)) + '\x01\x04\x04\x02\xFF';
+			self.sendVISCACommand(cmd);
+			break;
+
+		case 'wbBlueDown':
+			cmd = String.fromCharCode(parseInt(self.config.id)) + '\x01\x04\x04\x03\xFF';
+			self.sendVISCACommand(cmd);
+			break;
+
+		case 'wbOffsetReset':
+			cmd = String.fromCharCode(parseInt(self.config.id)) + '\x01\x7E\x01\x2E\x00\x00\xFF';
+			self.sendVISCACommand(cmd);
+			break;
+
+		case 'wbOffsetUp':
+			cmd = String.fromCharCode(parseInt(self.config.id)) + '\x01\x7E\x01\x2E\x00\x02\xFF';
+			self.sendVISCACommand(cmd);
+			break;
+
+		case 'wbOffsetDown':
+			cmd = String.fromCharCode(parseInt(self.config.id)) + '\x01\x7E\x01\x2E\x00\x03\xFF';
+			self.sendVISCACommand(cmd);
+			break;
+	
 		case 'WDR':
 			if (opt.val == 0) {
 				cmd = String.fromCharCode(parseInt(self.config.id)) + '\x01\x7E\x04\x00\x00\xFF';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "sony-visca",
-	"version": "1.2.11",
+	"version": "1.2.12",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Protocol",


### PR DESCRIPTION
Added actions and presets for more white balance control and rolled in an Auto Exposure Toggle preset, bumped version number

This pull request should close out issue [#27](https://github.com/bitfocus/companion-module-sony-visca/issues/27#issue-986830281)

Presets:
- White Balance Mode - Auto1
- White Balance Mode - Auto2
- White Balance Mode - Indoor
- White Balance Mode - Outdoor
- White Balance Mode - Manual
- White Balance Mode - Custom
- White Balance Mode - One Push
- White Balance - Trigger One Push
- White Balance - Red Gain Up
- White Balance - Red Gain Down
- White Balance - Blue Gain Up
- White Balance - Blue Gain Down
- White Balance - Offset Reset
- White Balance - Offset Up (more Red)
- White Balance - Offset Down (more Blue)
- Auto Exposure Toggle

Actions:
- One Push White Balance Trigger
- White Balance - Custom
- White Balance - Red Gain Up
- White Balance - Red Gain down
- White Balance - Blue Gain Up
- White Balance - Blue Gain Down
- White Balance - Offset Reset
- White Balance - Offset Up
- White Balance - Offset Down

Also updated the labels on some of the white balance modes to reflect the names Sony uses in the docs for their current cameras. Also noted the old name for those that still use them (ie: Auto2 - ATW)