### PR TITLE
Fixed error in Rotation Enabled preset for Pan/Tilt Speed preset

### DIFF
--- a/src/presets.js
+++ b/src/presets.js
@@ -2162,7 +2162,7 @@ const rotationEnabledPresets = {
 		category: 'Rotation Enabled',
 		name: 'Pan/Tilt Speed - tap for default',
 		style: {
-			text: 'Pan/Tilt\\nSpeed\\n$(VISCA:panSpeed)/$(VISCA:tiltSpeed)',
+			text: 'Pan/Tilt\\nSpeed\\n$(VISCA:panSpeed) / $(VISCA:tiltSpeed)',
 			size: '18',
 			color: COLORS.WHITE,
 			bgcolor: COLORS.BLACK,

--- a/src/presets.js
+++ b/src/presets.js
@@ -290,7 +290,7 @@ const panTiltPresets = {
 		category: 'Pan/Tilt',
 		name: 'Pan/Tilt Speed Up',
 		style: {
-			text: 'Pan/Tilt\\nFaster\\n$(VISCA:panSpeed)/$(VISCA:tiltSpeed)',
+			text: 'Pan/Tilt\\nFaster\\n$(VISCA:panSpeed) / $(VISCA:tiltSpeed)',
 			size: '18',
 			color: COLORS.WHITE,
 			bgcolor: COLORS.BLACK,
@@ -313,7 +313,7 @@ const panTiltPresets = {
 		category: 'Pan/Tilt',
 		name: 'Pan/Tilt Speed Down',
 		style: {
-			text: 'Pan/Tilt\\nSlower\\n$(VISCA:panSpeed)/$(VISCA:tiltSpeed)',
+			text: 'Pan/Tilt\\nSlower\\n$(VISCA:panSpeed) / $(VISCA:tiltSpeed)',
 			size: '18',
 			color: COLORS.WHITE,
 			bgcolor: COLORS.BLACK,


### PR DESCRIPTION
Currently the preset for Pan/Tilt Speed under Rotation Enabled is broken when you have changed the name of your connection. The Tilt speed variable in the button will not have the name replaced in the variable, therefor showing '$NA' by default. 

Adding a space is an easy fix!