### PR TITLE
Added action 'Recording Button (press/release)'

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1393,6 +1393,28 @@ function getMiscActionDefinitions(self, camId) {
 				self.checkFeedbacks()
 			},
 		},
+		internalRecording: {
+			name: 'Recording Button (press/release)',
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Press/Release',
+					id: 'bol',
+					choices: [
+						{ id: 1, label: 'Press' },
+						{ id: 0, label: 'Release' },
+					],
+					default: '1',
+				},
+			],
+			callback: async (event) => {
+				if (event.options.bol == 1) {
+					self.VISCA.send(camId + '\x01\x7E\x04\x1D\x01\xFF')
+				} else {
+					self.VISCA.send(camId + '\x01\x7E\x04\x1D\x00\xFF')
+				}
+			},
+		},
 		overrideViscaId: {
 			name: 'Override VISCA ID (serial only)',
 			description: 'Override the VISCA ID for this instance',

--- a/src/presets.js
+++ b/src/presets.js
@@ -1641,6 +1641,34 @@ const systemPresets = {
 		],
 		feedbacks: [],
 	},
+	'system-startStopRecording':{
+		type: 'button',
+		category: 'System',
+		name: 'Recording Button (press/release)',
+		style: {
+			text: 'Start\nStop\nRec',
+			size: '18',
+			color: COLORS.WHITE,
+			bgcolor: COLORS.BLACK,
+			show_topbar: false,
+		},
+		steps: [
+			{
+				down: [
+					{
+						actionId: 'internalRecording',
+						options: { bol: 1},
+					},
+				],
+				up: [
+					{
+						actionId: 'internalRecording',
+						options: { bol: 0},
+					},
+				],
+			},
+		],
+	},
 }
 
 const cameraPresets = {}


### PR DESCRIPTION
Added the action 'Recording Button (press/release)' supported by the Sony FR7.

Also added a Preset for this action.

	modified:   src/actions.js
	modified:   src/presets.js