### PR TITLE
Add support for the majority of CAM_PanTiltStatusInq

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -322,44 +322,58 @@ class SonyVISCAInstance extends InstanceBase {
 			switch (panRaw) {
 				case 0x00:
 					this.state.panStatus = 'Pan functioning normally'
+					break
 				case 0x01:
 					this.state.panStatus = 'Pan sensor issue'
+					break
 				case 0x02:
 					this.state.panStatus = 'Pan mechanism issue'
+					break
 				default:
 					this.state.panStatus = 'Unknown'
 			}
 			switch (tiltRaw) {
 				case 0x00:
 					this.state.tiltStatus = 'Tilt functioning normally'
+					break
 				case 0x01:
 					this.state.tiltStatus = 'Tilt sensor issue'
+					break
 				case 0x02:
 					this.state.tiltStatus = 'Tilt mechanism issue'
+					break
 				default:
 					this.state.tiltStatus = 'Unknown'
 			}
 			switch (operatingRaw) {
 				case 0x00:
 					this.state.panTiltOperatingStatus = 'No movement'
+					break
 				case 0x01:
 					this.state.panTiltOperatingStatus = 'Pan/Tilt operating'
+					break
 				case 0x02:
 					this.state.panTiltOperatingStatus = 'Pan/Tilt operation complete'
+					break
 				case 0x03:
 					this.state.panTiltOperatingStatus = 'Pan/Tilt operating failed'
+					break
 				default:
 					this.state.panTiltOperatingStatus = 'Unknown'
 			}
 			switch (initializingRaw) {
 				case 0x00:
 					this.state.panTiltInitializationStatus = 'Not initialized'
+					break
 				case 0x01:
 					this.state.panTiltInitializationStatus = 'Initializing'
+					break
 				case 0x02:
 					this.state.panTiltInitializationStatus = 'Initialization complete'
+					break
 				case 0x03:
 					this.state.panTiltInitializationStatus = 'Initialization failed'
+					break
 				default:
 					this.state.panTiltInitializationStatus = 'Unknown'
 			}

--- a/src/main.js
+++ b/src/main.js
@@ -51,6 +51,12 @@ class SonyVISCAInstance extends InstanceBase {
 			basisBrightnessLevel: 7,
 			viscaId: this.config.id,
 			presetSelector: 64,
+			panLimit: 'Unknown',
+			tiltLimit: 'Unknown',
+			panStatus: 'Unknown',
+			tiltStatus: 'Unknown',
+			panTiltOperatingStatus: 'Unknown',
+			panTiltInitializationStatus: 'Unknown',
 		}
 		this.speed = { pan: 0x0c, tilt: 0x0c, zoom: 1, focus: 1 }
 		this.tallyKeepaliveTimers = {}
@@ -291,6 +297,76 @@ class SonyVISCAInstance extends InstanceBase {
 					this.checkFeedbacks()
 				}
 			}
+		}
+		// CAM_PanTiltStatusInq: 8x 09 06 10 FF
+		// Standard: y0 50 pp pp FF         ( 2 bytes, 5 bytes)
+		callbacks['090610'] = (payload) => {
+			if (payload[1] !== 0x50) return
+			let initializingRaw, operatingRaw, tiltRaw, panRaw, limitRaw
+			if (payload.length >= 5) {
+				// FR7: 2 bytes
+				initializingRaw = (payload[2] & 0x30) >> 4
+				operatingRaw = (payload[2] & 0xc) >> 2
+				tiltRaw = payload[2] & 0x3
+				panRaw = (payload[3] & 0x30) >> 4
+				limitRaw = payload[3] & 0x8f
+				this.log('info', payload.toString('hex'))
+				this.log('info', 'Init: ' + initializingRaw.toString(2))
+				this.log('info', 'Operate: ' + operatingRaw.toString(2))
+				this.log('info', 'Tilt: ' + tiltRaw.toString(2))
+				this.log('info', 'Pan: ' + panRaw.toString(2))
+				this.log('info', 'Limit: ' + limitRaw.toString(2))
+			} else {
+				return
+			}
+			switch (panRaw) {
+				case 0x00:
+					this.state.panStatus = 'Pan functioning normally'
+				case 0x01:
+					this.state.panStatus = 'Pan sensor issue'
+				case 0x02:
+					this.state.panStatus = 'Pan mechanism issue'
+				default:
+					this.state.panStatus = 'Unknown'
+			}
+			switch (tiltRaw) {
+				case 0x00:
+					this.state.tiltStatus = 'Tilt functioning normally'
+				case 0x01:
+					this.state.tiltStatus = 'Tilt sensor issue'
+				case 0x02:
+					this.state.tiltStatus = 'Tilt mechanism issue'
+				default:
+					this.state.tiltStatus = 'Unknown'
+			}
+			switch (operatingRaw) {
+				case 0x00:
+					this.state.panTiltOperatingStatus = 'No movement'
+				case 0x01:
+					this.state.panTiltOperatingStatus = 'Pan/Tilt operating'
+				case 0x02:
+					this.state.panTiltOperatingStatus = 'Pan/Tilt operation complete'
+				case 0x03:
+					this.state.panTiltOperatingStatus = 'Pan/Tilt operating failed'
+				default:
+					this.state.panTiltOperatingStatus = 'Unknown'
+			}
+			switch (initializingRaw) {
+				case 0x00:
+					this.state.panTiltInitializationStatus = 'Not initialized'
+				case 0x01:
+					this.state.panTiltInitializationStatus = 'Initializing'
+				case 0x02:
+					this.state.panTiltInitializationStatus = 'Initialization complete'
+				case 0x03:
+					this.state.panTiltInitializationStatus = 'Initialization failed'
+				default:
+					this.state.panTiltInitializationStatus = 'Unknown'
+			}
+			// this.state.panLimit = 'Unknown'
+			// this.state.tiltLimit = 'Unknown'
+			this.updateVariables()
+			this.checkFeedbacks()
 		}
 		// CAM_PanTiltPosInq: 8x 09 06 12 FF
 		// Standard: y0 50 0p 0p 0p 0p 0t 0t 0t 0t FF         (4+4 nibble, 10 bytes)

--- a/src/variables.js
+++ b/src/variables.js
@@ -429,6 +429,12 @@ export async function updateVariables() {
 		presetSelector: this.state.presetSelector,
 		lastPresetUsed: this.state.lastPresetUsed,
 		viscaId: this.state.viscaId - 0x80,
+		panLimit: this.state.panLimit,
+		tiltLimit: this.state.tiltLimit,
+		panStatus: this.state.panStatus,
+		tiltStatus: this.state.tiltStatus,
+		panTiltOperatingStatus: this.state.panTiltOperatingStatus,
+		panTiltInitializationStatus: this.state.panTiltInitializationStatus,
 		// Block 097e7e00 — Lens Control
 		zoomPosition: this.state.zoomPosition,
 		focusPosition: this.state.focusPosition,

--- a/src/variables.js
+++ b/src/variables.js
@@ -273,6 +273,13 @@ const variables = [
 	{ variableId: 'zoomPositionBar', name: 'Zoom Position Bar' },
 	{ variableId: 'focusPositionBar', name: 'Focus Position Bar' },
 	{ variableId: 'irisPositionBar', name: 'Iris Position Bar' },
+	// Pan/Tilt status
+	{ variableId: 'panLimit', name: 'Pan Limit' },
+	{ variableId: 'tiltLimit', name: 'Tilt Limit' },
+	{ variableId: 'panStatus', name: 'Pan Status' },
+	{ variableId: 'tiltStatus', name: 'Tilt Status' },
+	{ variableId: 'panTiltOperatingStatus', name: 'Pan/Tilt Operating Status' },
+	{ variableId: 'panTiltInitializationStatus', name: 'Pan/Tilt Initialization Status' },
 	// Block 097e7e00 — Lens Control
 	{ variableId: 'zoomPosition', name: 'Zoom Position', block: '097e7e00' },
 	{ variableId: 'focusPosition', name: 'Focus Position', block: '097e7e00' },


### PR DESCRIPTION
Inquiry polling and variables initially

<img width="615" height="436" alt="image" src="https://github.com/user-attachments/assets/8544d4f8-5c09-4c1e-a458-675dabb23388" />
I'm not currently checking for the MSB of the second byte to be 0. I'm also curious if it's a typo that's not shown for the pan status bits...

Naming/feedback etc is probably one of the key things for all of this...